### PR TITLE
feat: limit NodePool providers to eight

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -39,8 +39,10 @@ type NodePoolSpec struct {
 	// Providers is the ordered set of NeoClouds this pool is allowed to use.
 	// A Pod bound to this pool can only ever be placed on a provider in this
 	// list. Order is significant only for the Ordered strategy (it is the
-	// inner, provider-ranking axis).
+	// inner, provider-ranking axis). A pool can list at most 8 providers so the
+	// candidate set remains bounded while larger configurations are unproven.
 	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:MaxItems=8
 	Providers []ProviderSpec `json:"providers"`
 
 	// CapacityTypes is the OUTER axis: the purchase models to try, in fallback

--- a/config/crd/bases/nebula.inftyai.com_nodepools.yaml
+++ b/config/crd/bases/nebula.inftyai.com_nodepools.yaml
@@ -112,7 +112,8 @@ spec:
                   Providers is the ordered set of NeoClouds this pool is allowed to use.
                   A Pod bound to this pool can only ever be placed on a provider in this
                   list. Order is significant only for the Ordered strategy (it is the
-                  inner, provider-ranking axis).
+                  inner, provider-ranking axis). A pool can list at most 8 providers so the
+                  candidate set remains bounded while larger configurations are unproven.
                 items:
                   description: |-
                     ProviderSpec is one provider's entry in a pool: which provider, and the
@@ -159,6 +160,7 @@ spec:
                   required:
                   - name
                   type: object
+                maxItems: 8
                 minItems: 1
                 type: array
               strategy:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -470,6 +470,10 @@ status:
 When `capacityTypes` is omitted, the API defaults it to `{OnDemand, Spot}`. The
 listed order is the fallback order the placement controller walks.
 
+A pool must list between one and eight providers. The upper bound keeps the
+provider-by-region candidate expansion bounded while performance at larger
+provider counts remains unproven.
+
 ### NodeClaim (`nc`)
 
 ```yaml

--- a/internal/controller/nodepool_validation_test.go
+++ b/internal/controller/nodepool_validation_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -25,11 +27,11 @@ import (
 	nebulav1alpha1 "github.com/InftyAI/Nebula/api/v1alpha1"
 )
 
-// These specs exercise the CEL validation rule on NodePoolSpec, which is only
-// enforced by a real apiserver (the fake client used by the unit tests does not
-// run CRD x-kubernetes-validations). They require envtest binaries; when those
+// These specs exercise CRD validation on NodePoolSpec, which is only enforced
+// by a real apiserver (the fake client used by the unit tests does not apply the
+// structural schema or CEL rules). They require envtest binaries; when those
 // are absent the whole suite is skipped in BeforeSuite.
-var _ = Describe("NodePool spec validation (CEL)", func() {
+var _ = Describe("NodePool spec validation", func() {
 	newWeightedPool := func(name string, refs ...nebulav1alpha1.ProviderSpec) *nebulav1alpha1.NodePool {
 		return &nebulav1alpha1.NodePool{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
@@ -40,6 +42,26 @@ var _ = Describe("NodePool spec validation (CEL)", func() {
 		}
 	}
 	weight := func(w int32) *int32 { return &w }
+	providerRefs := func(count int) []nebulav1alpha1.ProviderSpec {
+		refs := make([]nebulav1alpha1.ProviderSpec, count)
+		for i := range refs {
+			refs[i].Name = fmt.Sprintf("provider-%d", i)
+		}
+		return refs
+	}
+
+	It("admits a pool with eight providers", func() {
+		pool := newPool("eight-providers", nebulav1alpha1.StrategyOrdered, providerRefs(8)...)
+		Expect(k8sClient.Create(ctx, pool)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, pool)).To(Succeed())
+	})
+
+	It("rejects a pool with more than eight providers", func() {
+		pool := newPool("nine-providers", nebulav1alpha1.StrategyOrdered, providerRefs(9)...)
+		err := k8sClient.Create(ctx, pool)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("must have at most 8 items"))
+	})
 
 	It("rejects a Weighted pool with a provider missing a weight", func() {
 		pool := newWeightedPool("weighted-missing",


### PR DESCRIPTION
#### What this PR does / why we need it

NodePool already requires at least one provider, but it currently accepts an unbounded provider list. This change:

- adds the requested `MaxItems=8` API validation marker and regenerates the NodePool CRD;
- documents the bound and its candidate-expansion rationale in the canonical architecture guide;
- adds real-apiserver envtest coverage for the exact boundary: eight providers are accepted and nine are rejected.

The regression was run before the production marker and failed because the nine-provider object was accepted.

Artifacts requested in #29:

- Design/docs: `docs/architecture.md` records the bound and rationale.
- API: `NodePoolSpec.providers` and the generated CRD carry `maxItems: 8`.
- Tests: `nodepool_validation_test.go` exercises admission through envtest.

#### Which issue(s) this PR fixes

Fixes #29

#### Special notes for your reviewer

Validation completed locally with the repository's Kubernetes 1.33 envtest assets and the `go.mod` Go 1.24.0 toolchain:

- full non-e2e Go test suite, including envtest
- `go vet ./...`
- manager binary build
- `golangci-lint` v2.1.6 (`0 issues`)
- `git diff --check`

Repeated generation also produced the expected NodePool CRD schema. Unrelated pre-existing generated-description drift was intentionally excluded from this PR.

#### Does this PR introduce a user-facing change?

```release-note
action required: NodePool specs may contain at most eight providers. Existing NodePools with more than eight providers must be reduced before their next update.
```
