### PR TITLE
Add sandbox short aliases

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -230,7 +230,7 @@ type SandboxStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Namespaced,shortName=sbx
+// +kubebuilder:resource:scope=Namespaced,shortName={sb,sbx}
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Pool",type=string,JSONPath=`.spec.nodePoolRef`

--- a/api/v1alpha1/sandboxset_types.go
+++ b/api/v1alpha1/sandboxset_types.go
@@ -141,7 +141,7 @@ type SandboxSetStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:scope=Namespaced,shortName=sbxs
+// +kubebuilder:resource:scope=Namespaced,shortName={sbs,sbxs}
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="Desired",type=integer,JSONPath=`.spec.replicas`

--- a/config/crd/bases/nebula.inftyai.com_sandboxes.yaml
+++ b/config/crd/bases/nebula.inftyai.com_sandboxes.yaml
@@ -12,6 +12,7 @@ spec:
     listKind: SandboxList
     plural: sandboxes
     shortNames:
+    - sb
     - sbx
     singular: sandbox
   scope: Namespaced

--- a/config/crd/bases/nebula.inftyai.com_sandboxsets.yaml
+++ b/config/crd/bases/nebula.inftyai.com_sandboxsets.yaml
@@ -12,6 +12,7 @@ spec:
     listKind: SandboxSetList
     plural: sandboxsets
     shortNames:
+    - sbs
     - sbxs
     singular: sandboxset
   scope: Namespaced

--- a/config/samples/sandboxset.yaml
+++ b/config/samples/sandboxset.yaml
@@ -1,8 +1,8 @@
 # Maintains N Sandboxes. Provisioning an instance takes MINUTES while an agent's
 # exec call wants sub-second, so boxes are kept ready ahead of demand:
 #
-#   kubectl get sandboxes -l nebula.inftyai.com/sandboxset=sample
-#   kubectl scale sandboxset/sample --replicas=5
+#   kubectl get sb -l nebula.inftyai.com/sandboxset=sample
+#   kubectl scale sbs/sample --replicas=5
 #
 # Boxes get generated names (sample-a4f2x), not ordinals, because an ordinal would
 # imply a slot that gets refilled — a replacement box wearing a dead box's name is


### PR DESCRIPTION
## Summary
- Add `sb` as a short name for Sandbox while retaining `sbx`.
- Add `sbs` as a short name for SandboxSet while retaining `sbxs`.
- Regenerate CRD manifests and update sample comments to show the aliases.


Closes #34