### PR TITLE
fix: Show all nodepool providers in kubectl get columns

### DIFF
--- a/api/v1alpha1/nodepool_types.go
+++ b/api/v1alpha1/nodepool_types.go
@@ -252,6 +252,12 @@ type NodePoolStatus struct {
 	// +optional
 	Placed map[string]int32 `json:"placed,omitempty"`
 
+	// Providers is a comma-separated list of provider names from the pool
+	// spec. kubectl printcolumns cannot join array fields via JSONPath, so
+	// the controller materializes this summary for `kubectl get nodepool`.
+	// +optional
+	Providers string `json:"providers,omitempty"`
+
 	// Conditions follows the standard Kubernetes condition convention.
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
@@ -261,7 +267,7 @@ type NodePoolStatus struct {
 // +kubebuilder:resource:scope=Cluster,shortName=np
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Strategy",type=string,JSONPath=`.spec.strategy`
-// +kubebuilder:printcolumn:name="Providers",type=string,JSONPath=`.spec.providers[*].name`
+// +kubebuilder:printcolumn:name="Providers",type=string,JSONPath=`.status.providers`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // NodePool is the placement policy for GPU workloads across NeoClouds.

--- a/internal/controller/nodepool_controller.go
+++ b/internal/controller/nodepool_controller.go
@@ -148,6 +148,12 @@ func (r *NodePoolReconciler) refreshPlaced(ctx context.Context, pool *nebulav1al
 	if len(placed) == 0 {
 		placed = nil // keep status clean when nothing is placed
 	}
+	// Materialize provider names for the kubectl column (JSONPath cannot join arrays).
+	names := make([]string, 0, len(pool.Spec.Providers))
+	for _, p := range pool.Spec.Providers {
+		names = append(names, p.Name)
+	}
+	pool.Status.Providers = strings.Join(names, ",")
 	pool.Status.Placed = placed
 	return nil
 }


### PR DESCRIPTION
## Summary

Show all nodepool providers in kubectl get columns

## Changes

- Add status.providers comma-joined summary (JSONPath cannot join arrays)
- Point Providers printcolumn at status.providers
- Controller fills status.providers from spec on reconcile

Fixes #28
